### PR TITLE
Support for map zooming with mouse wheel

### DIFF
--- a/Assets/Scripts/Game/Navigation/Globe/GlobeController.cs
+++ b/Assets/Scripts/Game/Navigation/Globe/GlobeController.cs
@@ -11,6 +11,7 @@ public class GlobeController : MonoBehaviour
 	public bool allowMouseRotation = true;
 	public float poleAngleLimit = 15;
 	public float mouseSensitivity;
+	public float zoomSensitivity = 4;
 	public float fadeSpeed = 2;
 
 	public Color highlightCol;
@@ -116,12 +117,29 @@ public class GlobeController : MonoBehaviour
 
 			mousePosOld = mousePos;
 			UpdateRotation();
+			UpdateZooming();
 
 			cam.fieldOfView = Mathf.SmoothDamp(cam.fieldOfView, targetZoom, ref smoothZoomV, 0.2f);
 		}
 
 		UpdateHighlightState();
 
+	}
+
+	void UpdateZooming()
+	{
+		if (Input.mouseScrollDelta.y == 0) return;
+
+		targetZoom -= Input.mouseScrollDelta.y * zoomSensitivity;
+
+		if (targetZoom >= zoomMinMax.x)
+		{
+			SetZoomState(false);
+		}
+		else if (targetZoom <= zoomMinMax.y)
+		{
+			SetZoomState(true);
+		}
 	}
 
 	void ClampAngleY()


### PR DESCRIPTION
The map is very intuitive to use but I think zooming between fixed values using a toggle button feels off, at least on PC.

I have kept the zoom button for now and its state automatically updates when you've zoomed all the way in or out with the mouse wheel, however, I think it would be best to only show the button on touch devices (if you plan on making the game compatible with phones/tables).

https://user-images.githubusercontent.com/57709490/167035039-2c5b1316-2172-4a29-b8bb-8f4703b39056.mp4


