### PR TITLE
Fix Astana, capital of Kazakhstan (this fixes #43)

### DIFF
--- a/Assets/Data/Countries/Capitals.json
+++ b/Assets/Data/Countries/Capitals.json
@@ -18289,7 +18289,7 @@
             ]
         },
         "capital": [
-            "Nur-Sultan"
+            "Astana"
         ],
         "altSpellings": [
             "KZ",

--- a/Assets/Data/Quest/Locations.asset
+++ b/Assets/Data/Quest/Locations.asset
@@ -706,7 +706,7 @@ MonoBehaviour:
   - countryName: Kazakhstan
     countryCode3: KAZ
     curatedCities:
-    - cityName: Nur-Sultan
+    - cityName: Astana
       overrideCountryName: 
       overrideCountryFlagCode: 
   - countryName: Kenya


### PR DESCRIPTION
Evidently you need to multiply actual LatLong by 0.017442351 to get in-game coordinates. Astana holds the Guiness World record for the capital city with the most name changes in modern times. We will likely need a patch like this every few years to keep up.