### PR TITLE
Changing the translation of "language"

### DIFF
--- a/Assets/Data/Localization/French/MenuLocalization.json
+++ b/Assets/Data/Localization/French/MenuLocalization.json
@@ -34,7 +34,7 @@
         },
         {
             "id": "settingsMenu.audioAndLanguageTab",
-            "text": "Audio / Langage"
+            "text": "Audio / Langue"
         },
         {
             "id": "settingsMenu.controlsTab",
@@ -66,7 +66,7 @@
         },
         {
             "id": "settingsMenu.audioAndLanguage.language",
-            "text": "Langage"
+            "text": "Langue"
         },
         {
             "id": "settingsMenu.audioAndLanguage.translationNote",


### PR DESCRIPTION
In this context, it's might be better to use the word "langue" instead of "langage" to translate "language" when it refers to a human spoken language. "langage" is used in more general cases than human languages like programming languages (langages de programmation).